### PR TITLE
Flag compiler warnings in CI builds of operational applications via GitHub Action

### DIFF
--- a/.github/scripts/check_build_compile_warnings.py
+++ b/.github/scripts/check_build_compile_warnings.py
@@ -183,6 +183,18 @@ if __name__ == "__main__":
     print("--------------------------------------\n")
     
     all_warnings = parse_spack_logs(log_directory)
+
+    # Address duplicate warnings (across application builds)
+    unique_warnings = []
+    seen_signatures = set()
+    for w in all_warnings:
+        # Create a unique signature for this exact warning
+        sig = (w['file'], w['line'], w['msg'])
+        if sig not in seen_signatures:
+            seen_signatures.add(sig)
+            unique_warnings.append(w)
+    print(f"🧹 {len(unique_warnings)}/{len(all_warnings)} are unique compiler warnings.")        
+    all_warnings = unique_warnings
     
     # 1. Save the full list of legacy warnings to a file for monitoring
     with open("all_compiler_warnings.txt", "w") as f:

--- a/.github/scripts/check_build_compile_warnings.py
+++ b/.github/scripts/check_build_compile_warnings.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+import os, sys, re, subprocess, glob
+
+def get_submodule_url(gitmodules_file, sub_path):
+    """Extracts the exact URL for a submodule path from a .gitmodules file, regardless of its internal alias."""
+    if not os.path.exists(gitmodules_file):
+        return ""
+        
+    # Find the internal name by matching the file path
+    name_cmd = subprocess.run(["git", "config", "--file", gitmodules_file, "--get-regexp", r"^submodule\..*\.path$"], capture_output=True, text=True)
+    
+    for line in name_cmd.stdout.splitlines():
+        # Line format looks like: submodule.cice.path CICE-interface/CICE
+        if line.strip().endswith(f" {sub_path}"):
+            internal_key = line.split(".path")[0]  # Extracts 'submodule.cice'
+            url_cmd = subprocess.run(["git", "config", "--file", gitmodules_file, f"{internal_key}.url"], capture_output=True, text=True)
+            return url_cmd.stdout.strip()
+            
+    return ""
+
+def get_changed_lines(repo_path, diff_args, path_prefix=""):
+    """Recursively parses diffs, seamlessly traversing nested submodules and fork changes."""
+    cmd = ["git", "-C", repo_path, "diff", "--unified=0"] + diff_args
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    
+    # Catch and print failures for the main diff!
+    if result.returncode != 0:
+        print(f"⚠️ GIT DIFF ERROR in '{repo_path}': {result.stderr.strip()}")
+        
+    changed = {}
+    current_file = None
+    old_hash = ""
+    
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            changed[f"{path_prefix}{current_file}"] = set()
+            
+        elif line.startswith("@@ ") and current_file:
+            m = re.search(r'\+([0-9]+)(?:,([0-9]+))?', line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2)) if m.group(2) else 1
+                for i in range(start, start + count):
+                    changed[f"{path_prefix}{current_file}"].add(i)
+                    
+        # Submodule updates 
+        elif line.startswith("-Subproject commit "):
+            old_hash = line.split()[2]
+        elif line.startswith("+Subproject commit ") and current_file and old_hash:
+            new_hash = line.split()[2]
+            sub_name = current_file 
+            sub_path_full = os.path.join(repo_path, sub_name) if repo_path != "." else sub_name
+            
+            print(f"📦 Traversing nested submodule: '{path_prefix}{sub_name}'...")
+            
+            # Catch init failures
+            init_cmd = subprocess.run(["git", "-C", repo_path, "submodule", "update", "--init", sub_name], capture_output=True, text=True)
+            if init_cmd.returncode != 0:
+                print(f"   ⚠️ Submodule Init failed: {init_cmd.stderr.strip()}")
+            
+            old_url, new_url = "", ""
+            
+            # CRITICAL FIX: Decouple the parent's repo refs from the child's submodule hashes
+            if len(diff_args) == 2:
+                parent_old_ref, parent_new_ref = diff_args[0], diff_args[1]
+            else:
+                parent_old_ref = diff_args[0].split("...")[0] if "..." in diff_args[0] else "HEAD"
+                parent_new_ref = "HEAD"
+            
+            old_gm = subprocess.run(["git", "-C", repo_path, "show", f"{parent_old_ref}:.gitmodules"], capture_output=True, text=True)
+            if old_gm.returncode == 0:
+                # Use a unique temp file name to prevent overwriting during deep recursion
+                temp_old = os.path.join(repo_path, f".gitmodules_old_{sub_name.replace('/', '_')}")
+                with open(temp_old, "w") as f: f.write(old_gm.stdout)
+                old_url = get_submodule_url(temp_old, sub_name)
+            else:
+                print(f"   ⚠️ Could not read old .gitmodules: {old_gm.stderr.strip()}")
+            
+            new_gm = subprocess.run(["git", "-C", repo_path, "show", f"{parent_new_ref}:.gitmodules"], capture_output=True, text=True)
+            if new_gm.returncode == 0:
+                temp_new = os.path.join(repo_path, f".gitmodules_new_{sub_name.replace('/', '_')}")
+                with open(temp_new, "w") as f: f.write(new_gm.stdout)
+                new_url = get_submodule_url(temp_new, sub_name)
+            
+            # Catch and print fetch failures, with aggressive fallback for all branches
+            if old_url:
+                print(f"   ⬇️ Fetching old hash {old_hash[:7]} from {old_url}")
+                f1 = subprocess.run(["git", "-C", sub_path_full, "fetch", old_url, old_hash], capture_output=True, text=True)
+                if f1.returncode != 0:
+                    print(f"   ⚠️ Direct hash fetch failed. Falling back to full branch fetch: {f1.stderr.strip()}")
+                    subprocess.run(["git", "-C", sub_path_full, "fetch", old_url, "+refs/heads/*:refs/remotes/temp_old/*"], capture_output=True)
+                    
+            if new_url:
+                print(f"   ⬇️ Fetching new hash {new_hash[:7]} from {new_url}")
+                f2 = subprocess.run(["git", "-C", sub_path_full, "fetch", new_url, new_hash], capture_output=True, text=True)
+                if f2.returncode != 0:
+                    print(f"   ⚠️ Direct hash fetch failed. Falling back to full branch fetch: {f2.stderr.strip()}")
+                    subprocess.run(["git", "-C", sub_path_full, "fetch", new_url, "+refs/heads/*:refs/remotes/temp_new/*"], capture_output=True)
+            
+            # Recursively append changes
+            sub_changed = get_changed_lines(sub_path_full, [old_hash, new_hash], f"{path_prefix}{sub_name}/")
+            for filepath, lines in sub_changed.items():
+                if filepath not in changed:
+                    changed[filepath] = set()
+                changed[filepath].update(lines)
+            
+            old_hash = "" 
+
+    return changed
+
+def parse_spack_logs(log_dir):
+    """Parses Spack build logs to find warnings and strips staging paths."""
+    warnings = []
+    log_files = []
+    
+    # 1. Replicate the bash 'find' command to catch all build-out files, regardless of extension
+    for root, _, files in os.walk(log_dir):
+        for file in files:
+            if "build-out" in file:
+                log_files.append(os.path.join(root, file))
+                
+    print(f"🔍 Found {len(log_files)} Spack log files to parse.")
+    
+    for filepath in log_files:
+        with open(filepath, 'r', errors='replace') as f:
+            current_file, current_line = None, None
+            
+            for line in f:
+                # 1. Match ANY absolute file path that ends in a source extension and has a line number
+                loc_match = re.search(r'(/.*?\.(?:F90|f90|F|f|c|cpp|h))(?::|\()([0-9]+)[:\)]', line, re.IGNORECASE)
+                
+                if loc_match:
+                    raw_path = loc_match.group(1)
+                    current_line = int(loc_match.group(2))
+                    
+                    # Clean the path to make it relative to the git repo root
+                    current_file = raw_path
+                    for marker in ['spack-devpkg-ufs-weather-model/', 'spack-src/', 'ufs-weather-model/']:
+                        if marker in current_file:
+                            current_file = current_file.split(marker)[-1]
+                            break
+                            
+                    current_file = current_file.strip()
+                    
+                    # Intel compiler often prints warning on the same line as the path
+                    if 'warning' in line.lower(): 
+                        warnings.append({'file': current_file, 'line': current_line, 'msg': line.strip()})
+                        current_file, current_line = None, None
+                    continue
+                
+                # 2. Match GNU multiline warnings (e.g. "Warning: Possible change...")
+                if current_file and current_line and re.search(r'^[Ww]arning:', line.strip()):
+                    warnings.append({
+                        'file': current_file,
+                        'line': current_line,
+                        'msg': line.strip()
+                    })
+                    # Reset context to avoid attaching future warnings to the wrong line
+                    current_file, current_line = None, None 
+                    
+    return warnings
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 check_build_compile_warnings.py <path_to_spack_logs>")
+        sys.exit(1)
+        
+    log_directory = sys.argv[1]
+    base_branch = "develop"
+    
+    print(f"Checking diff against origin/{base_branch}...")
+    
+    # 1. Main PR diff uses the three-dot syntax as a single string in the list
+    changed_lines = get_changed_lines(".", [f"origin/{base_branch}...HEAD"])
+    
+    # 2. DEBUG PRINT: Show exactly what files and lines the script mapped
+    print("\n--- DEBUG: MODIFIED FILES DETECTED ---")
+    if not changed_lines:
+        print("No modified code files found in diff.")
+    for f, lines in changed_lines.items():
+        print(f"  - {f} ({len(lines)} lines modified)")
+    print("--------------------------------------\n")
+    
+    all_warnings = parse_spack_logs(log_directory)
+    
+    # 1. Save the full list of legacy warnings to a file for monitoring
+    with open("all_compiler_warnings.txt", "w") as f:
+        for w in all_warnings:
+            # This ONLY writes to the artifact text file, it does not print to the screen
+            f.write(f"{w['file']}:{w['line']} {w['msg']}\n")
+    
+    new_warnings = []
+    for w in all_warnings:
+        if w['file'] in changed_lines and w['line'] in changed_lines[w['file']]:
+            new_warnings.append(w)
+            
+    # 2. Write a native Markdown summary to the GitHub Actions UI
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as summary:
+            summary.write("## 🛠️ Compiler Warnings Report\n\n")
+            summary.write(f"**Total Warnings in Codebase:** {len(all_warnings)}\n")
+            summary.write(f"**New Warnings Introduced:** {len(new_warnings)}\n\n")
+            summary.write("> *Download `all_compiler_warnings.txt` from the artifacts below to see the full legacy list.*\n")
+
+    # 3. Handle the PR outcome
+    if not new_warnings:
+        print(f"Success! System has {len(all_warnings)} legacy warnings, but ZERO new warnings.")
+        sys.exit(0)
+        
+    print(f"FAILED: Found {len(new_warnings)} new warnings introduced in this PR!\n")
+    for w in new_warnings:
+        # 1. Print a human-readable version so developers can read the raw text logs
+        print(f"File: {w['file']} | Line: {w['line']}")
+        print(f"Message: {w['msg']}\n")
+        
+        # 2. Native GitHub inline PR comment (GitHub intercepts this specific syntax)
+        print(f"::error file={w['file']},line={w['line']}::{w['msg']}")
+        
+    sys.exit(1)

--- a/.github/scripts/check_build_compile_warnings.py
+++ b/.github/scripts/check_build_compile_warnings.py
@@ -161,13 +161,8 @@ def parse_spack_logs(log_dir):
                     
     return warnings
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python3 check_build_compile_warnings.py <path_to_spack_logs>")
-        sys.exit(1)
-        
-    log_directory = sys.argv[1]
-    base_branch = "develop"
+def driver_check_build_warnings(log_directory, base_branch):
+    """Driver to filter Spack build logs for legacy and new warnings."""
     
     print(f"Checking diff against origin/{base_branch}...")
     
@@ -183,18 +178,7 @@ if __name__ == "__main__":
     print("--------------------------------------\n")
     
     all_warnings = parse_spack_logs(log_directory)
-
-    # # Address duplicate warnings (across application builds)
-    # unique_warnings = []
-    # seen_signatures = set()
-    # for w in all_warnings:
-    #    # Create a unique signature for this exact warning
-    #    sig = (w['file'], w['line'], w['msg'])
-    #    if sig not in seen_signatures:
-    #        seen_signatures.add(sig)
-    #        unique_warnings.append(w)
-    # print(f"🧹 {len(unique_warnings)}/{len(all_warnings)} are unique compiler warnings.")        
-    # all_warnings = unique_warnings
+    # Possible TODO: duplicate warnings (across application builds)
     
     # 1. Save the full list of legacy warnings to a file for monitoring
     with open("all_compiler_warnings.txt", "w") as f:
@@ -231,3 +215,13 @@ if __name__ == "__main__":
         print(f"::error file={w['file']},line={w['line']}::{w['msg']}")
         
     sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 check_build_compile_warnings.py <path_to_spack_logs>")
+        sys.exit(1)
+        
+    log_directory = sys.argv[1]
+    base_branch = "develop"
+
+    driver_check_build_warnings(log_directory, base_branch)

--- a/.github/scripts/check_build_compile_warnings.py
+++ b/.github/scripts/check_build_compile_warnings.py
@@ -184,17 +184,17 @@ if __name__ == "__main__":
     
     all_warnings = parse_spack_logs(log_directory)
 
-    # Address duplicate warnings (across application builds)
-    unique_warnings = []
-    seen_signatures = set()
-    for w in all_warnings:
-        # Create a unique signature for this exact warning
-        sig = (w['file'], w['line'], w['msg'])
-        if sig not in seen_signatures:
-            seen_signatures.add(sig)
-            unique_warnings.append(w)
-    print(f"🧹 {len(unique_warnings)}/{len(all_warnings)} are unique compiler warnings.")        
-    all_warnings = unique_warnings
+    # # Address duplicate warnings (across application builds)
+    # unique_warnings = []
+    # seen_signatures = set()
+    # for w in all_warnings:
+    #    # Create a unique signature for this exact warning
+    #    sig = (w['file'], w['line'], w['msg'])
+    #    if sig not in seen_signatures:
+    #        seen_signatures.add(sig)
+    #        unique_warnings.append(w)
+    # print(f"🧹 {len(unique_warnings)}/{len(all_warnings)} are unique compiler warnings.")        
+    # all_warnings = unique_warnings
     
     # 1. Save the full list of legacy warnings to a file for monitoring
     with open("all_compiler_warnings.txt", "w") as f:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     - name: "Checkout"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
         path: ufs-weather-model
@@ -101,7 +101,7 @@ jobs:
         cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out.txt
     - name: "Upload Build Logs"
       if: always() # Run this even if the build fails
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: spack-build-logs-${{ matrix.app }}-${{ matrix.compiler.name }}
         path: spack-logs/spack-build-out.txt
@@ -110,7 +110,7 @@ jobs:
   # Parse build logs and annotate GitHub PR with new compiler warnings
   # -------------------------------------------------------------------------
   check-warnings:
-    name: Check New Compiler Warnings
+    name: Check New and Legacy Compiler Warnings
     runs-on: ubuntu-24.04
     needs: [Spack]
     if: (success() || failure()) # Ensures this runs even if CMake compilation fails
@@ -120,18 +120,18 @@ jobs:
       
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 
           
       - name: Download Build Logs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: spack-build-logs-*
           path: ./spack-logs
           merge-multiple: true # Consolidates all matrix logs into the single folder
           
-      - name: Run Native Warning Check
+      - name: Run Compiler Warnings Check
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: |
@@ -144,9 +144,9 @@ jobs:
           echo "Running custom Python warning parser..."
           python ${{ github.workspace }}/.github/scripts/check_build_compile_warnings.py ./spack-logs
 
-      - name: Upload Legacy Warnings Report
+      - name: Upload Warnings Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          name: legacy-compiler-warnings
+          name: report-compiler-warnings
           path: all_compiler_warnings.txt

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,17 +15,22 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        app: ["S2SWA", "ATM"]
+        app: ["ATM", "S2SW", "HAFS-MOM6W"]
         compiler:
           - name: "gcc"
             container: "ghcr.io/noaa-emc/ci-common-build-cache/ufs-weather-model-ubuntu-24.04-gcc-13-mpich-x@sha256:cc9bdafb43d31498fe833c1914d90e32570f8fa9f001e11ca16c4a88417128f8"
           - name: "oneapi"
             container: "ghcr.io/noaa-emc/ci-common-build-cache/ufs-weather-model-ubuntu-24.04-oneapi-2025.3-intel-oneapi-mpi-2021.17@sha256:a8d5845388f64ed95ad19583b03536b68c48c2c2d8166f66269fac92fd2a0751"
         include:
-          - app: S2SWA
-            ccpp_suites: "FV3_GFS_v17_coupled_p8,FV3_GFS_v17_coupled_p8_ugwpv1"
-          - app: ATM
-            ccpp_suites: "FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v17_p8_ugwpv1"
+          - app: ATM # cover RRFS
+            ccpp_suites: "FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl"
+            cmake_args: ""
+          - app: S2SW # cover GFS (and SFS)
+            ccpp_suites: "FV3_GFS_v17_coupled_p8_ugwpv1"
+            cmake_args: "-DPDLIB=ON -DUFS_TRACING=ON"
+          - app: HAFS-MOM6W # cover HAFS
+            ccpp_suites: "FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_thompson_nonsst"
+            cmake_args: ""
 
     runs-on: ${{ matrix.os }}
     # Dependencies are preinstalled in a container image.
@@ -89,7 +94,8 @@ jobs:
           -D32BIT=ON \
           -DUSE_ESMF_STATIC_LIBS=OFF \
           -DCMAKE_MODULE_PATH=$esmfcmakemoddir \
-          -DDEBUG=ON
+          -DDEBUG=ON \
+          ${{ matrix.cmake_args }}
         # Save compile logs to check warnings
         mkdir -p spack-logs
         cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out.txt

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -88,6 +88,13 @@ jobs:
           export CC=mpicc ; export CXX=mpic++ ; export FC=mpif90
         fi
         esmfcmakemoddir=$(spack location --install-dir esmf)/cmake
+        libcmakedir=""
+        # Only locate and inject SCOTCH_DIR if PDLIB is enabled for this matrix job
+        if [[ "${{ matrix.cmake_args }}" == *"-DPDLIB=ON"* ]]; then
+          scotch_dir=$(spack location --install-dir scotch)
+          echo "PDLIB is enabled. Injecting SCOTCH_DIR=$scotch_dir"
+          libcmakedir="-DSCOTCH_DIR=$scotch_dir"
+        fi
         cmake -S $GITHUB_WORKSPACE/ufs-weather-model -B build \
           -DAPP=${{ matrix.app }} \
           -DCCPP_SUITES=${{ matrix.ccpp_suites }} \
@@ -95,6 +102,7 @@ jobs:
           -DUSE_ESMF_STATIC_LIBS=OFF \
           -DCMAKE_MODULE_PATH=$esmfcmakemoddir \
           -DDEBUG=ON \
+          ${libcmakedir} \
           ${{ matrix.cmake_args }}
         # Save compile logs to check warnings
         mkdir -p spack-logs

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -27,7 +27,7 @@ jobs:
             cmake_args: ""
           - app: S2SW # cover GFS (and SFS)
             ccpp_suites: "FV3_GFS_v17_coupled_p8_ugwpv1"
-            cmake_args: "-DPDLIB=ON -DUFS_TRACING=ON"
+            cmake_args: "-DUFS_TRACING=ON" # TODO: -DPDLIB=ON
           - app: HAFS-MOM6W # cover HAFS
             ccpp_suites: "FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_thompson_nonsst"
             cmake_args: ""
@@ -88,13 +88,6 @@ jobs:
           export CC=mpicc ; export CXX=mpic++ ; export FC=mpif90
         fi
         esmfcmakemoddir=$(spack location --install-dir esmf)/cmake
-        libcmakedir=""
-        # Only locate and inject SCOTCH_DIR if PDLIB is enabled for this matrix job
-        if [[ "${{ matrix.cmake_args }}" == *"-DPDLIB=ON"* ]]; then
-          scotch_dir=$(spack location --install-dir scotch)
-          echo "PDLIB is enabled. Injecting SCOTCH_DIR=$scotch_dir"
-          libcmakedir="-DSCOTCH_DIR=$scotch_dir"
-        fi
         cmake -S $GITHUB_WORKSPACE/ufs-weather-model -B build \
           -DAPP=${{ matrix.app }} \
           -DCCPP_SUITES=${{ matrix.ccpp_suites }} \
@@ -102,7 +95,6 @@ jobs:
           -DUSE_ESMF_STATIC_LIBS=OFF \
           -DCMAKE_MODULE_PATH=$esmfcmakemoddir \
           -DDEBUG=ON \
-          ${libcmakedir} \
           ${{ matrix.cmake_args }}
         # Save compile logs to check warnings
         mkdir -p spack-logs

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     - name: "Checkout"
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
       with:
         submodules: recursive
         path: ufs-weather-model
@@ -98,13 +98,13 @@ jobs:
           ${{ matrix.cmake_args }}
         # Save compile logs to check warnings
         mkdir -p spack-logs
-        cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out.txt
+        cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out-${{ matrix.app }}-${{ matrix.compiler.name }}.txt
     - name: "Upload Build Logs"
       if: always() # Run this even if the build fails
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: spack-build-logs-${{ matrix.app }}-${{ matrix.compiler.name }}
-        path: spack-logs/spack-build-out.txt
+        path: spack-logs/spack-build-out-*.txt
 
   # -------------------------------------------------------------------------
   # Parse build logs and annotate GitHub PR with new compiler warnings
@@ -120,12 +120,12 @@ jobs:
       
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 
           
       - name: Download Build Logs
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: spack-build-logs-*
           path: ./spack-logs
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload Warnings Report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: report-compiler-warnings
           path: all_compiler_warnings.txt

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -55,6 +55,7 @@ jobs:
       shell: bash
       run: |
         set -x
+        set -o pipefail  # so cmake failure isn't masked by tee
         . /entrypoint.sh
         ############################
         ## Modify Spack installation, if needed
@@ -87,5 +88,59 @@ jobs:
           -DCCPP_SUITES=${{ matrix.ccpp_suites }} \
           -D32BIT=ON \
           -DUSE_ESMF_STATIC_LIBS=OFF \
-          -DCMAKE_MODULE_PATH=$esmfcmakemoddir
-        cmake --build build --parallel 4
+          -DCMAKE_MODULE_PATH=$esmfcmakemoddir \
+          -DDEBUG=ON
+        # Save compile logs to check warnings
+        mkdir -p spack-logs
+        cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out.txt
+    - name: "Upload Build Logs"
+      if: always() # Run this even if the build fails
+      uses: actions/upload-artifact@v4
+      with:
+        name: spack-build-logs-${{ matrix.app }}-${{ matrix.compiler.name }}
+        path: spack-logs/spack-build-out.txt
+
+  # -------------------------------------------------------------------------
+  # Parse build logs and annotate GitHub PR with new compiler warnings
+  # -------------------------------------------------------------------------
+  check-warnings:
+    name: Check New Compiler Warnings
+    runs-on: ubuntu-24.04
+    needs: [Spack]
+    if: (success() || failure()) # Ensures this runs even if CMake compilation fails
+    
+    permissions:
+      contents: read
+      
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+          
+      - name: Download Build Logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: spack-build-logs-*
+          path: ./spack-logs
+          merge-multiple: true # Consolidates all matrix logs into the single folder
+          
+      - name: Run Native Warning Check
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          echo "Fetching target branch for diff comparison..."
+          git fetch origin ${{ github.base_ref }}
+
+          echo "--- Build log files downloaded for check-warnings ---"
+          find ./spack-logs -type f
+          
+          echo "Running custom Python warning parser..."
+          python ${{ github.workspace }}/.github/scripts/check_build_compile_warnings.py ./spack-logs
+
+      - name: Upload Legacy Warnings Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: legacy-compiler-warnings
+          path: all_compiler_warnings.txt

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
     - name: "Checkout"
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         path: ufs-weather-model
@@ -101,7 +101,7 @@ jobs:
         cmake --build build --parallel 4 2>&1 | tee spack-logs/spack-build-out.txt
     - name: "Upload Build Logs"
       if: always() # Run this even if the build fails
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: spack-build-logs-${{ matrix.app }}-${{ matrix.compiler.name }}
         path: spack-logs/spack-build-out.txt
@@ -120,12 +120,12 @@ jobs:
       
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 
           
       - name: Download Build Logs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: spack-build-logs-*
           path: ./spack-logs
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload Warnings Report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: report-compiler-warnings
           path: all_compiler_warnings.txt

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        app: ["ATM", "S2SW", "HAFS-MOM6W", "NG-GODAS"]
+        app: ["ATM", "S2SW", "HAFS-MOM6W"]
         compiler:
           - name: "gcc"
             container: "ghcr.io/noaa-emc/ci-common-build-cache/ufs-weather-model-ubuntu-24.04-gcc-13-mpich-x@sha256:cc9bdafb43d31498fe833c1914d90e32570f8fa9f001e11ca16c4a88417128f8"
@@ -25,14 +25,11 @@ jobs:
           - app: ATM # cover RRFS
             ccpp_suites: "FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl"
             cmake_args: ""
-          - app: S2SW # cover GFS (and SFS)
+          - app: S2SW # cover GFS (and SFS, RTOFS too)
             ccpp_suites: "FV3_GFS_v17_coupled_p8_ugwpv1"
             cmake_args: "-DUFS_TRACING=ON" # TODO: -DPDLIB=ON
           - app: HAFS-MOM6W # cover HAFS
             ccpp_suites: "FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_thompson_nonsst"
-            cmake_args: ""
-          - app: NG-GODAS # cover RTOFS
-            ccpp_suites: ""
             cmake_args: ""
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
-        app: ["ATM", "S2SW", "HAFS-MOM6W"]
+        app: ["ATM", "S2SW", "HAFS-MOM6W", "NG-GODAS"]
         compiler:
           - name: "gcc"
             container: "ghcr.io/noaa-emc/ci-common-build-cache/ufs-weather-model-ubuntu-24.04-gcc-13-mpich-x@sha256:cc9bdafb43d31498fe833c1914d90e32570f8fa9f001e11ca16c4a88417128f8"
@@ -30,6 +30,9 @@ jobs:
             cmake_args: "-DUFS_TRACING=ON" # TODO: -DPDLIB=ON
           - app: HAFS-MOM6W # cover HAFS
             ccpp_suites: "FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_thompson_nonsst"
+            cmake_args: ""
+          - app: NG-GODAS # cover RTOFS
+            ccpp_suites: ""
             cmake_args: ""
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- INSTRUCTIONS: 
- READ/FOLLOW THE DIRECTIONS IN EACH SECTION
- Complete the 'Commit Queue Requirements' below
- Use GitHub markup as much as possible (https://docs.github.com/en/get-started/writing-on-github)
- Leave your PR in a draft state until all underlying work is completed.
-->

## Commit Queue Requirements:
<!--
- Check off completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your pull request (PR) will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
 -->
- [ ] This PR addresses a relevant WM issue (if not, create an issue). 
- [ ] All subcomponent pull requests (if any) have been reviewed by their code managers.
- [ ] Run the full Intel+GNU RT suite (compared to current baselines), preferably on Ursa (Derecho or Hercules are acceptable alternatives). **Exceptions:** documentation-only PRs, CI-only PRs, etc.
   - [ ] Commit log file w/full results from RT suite run (if applicable).
   - [ ] Verify that `test_changes.list` indicates which tests, if any, are changed by this PR. Commit `test_changes.list`, even if it is empty.
- [ ] Transparency in the use of generative AI is required by NOAA policy. Was GenAI used in this work?
   - [ ] [Generative AI tool (insert name, if any)] was used to assist with developing this code. The code has been reviewed, edited, and validated by NWS staff.
- [ ] Fill out all sections of this template.

---

## Description:
<!--
Provide a detailed verbose description of what this PR does
-->
Towards better code quality and operational readiness for EE2 requirements, we're looking for friendly ways of iterating with developers to reduce legacy compiler warnings and not introduce new ones.

This is a GitHub Action to flag existing and new compiler warnings for global to regional operational applications in debug mode CI builds. These complement the tracking of the number of warnings on supported platforms via the regression test platform logs.

This PR uploads the CI build logs, adds a parser in Python with a central regex filtering for warnings with file+line number, overlaps warnings with Git diff to ID new warnings, and logs+prints+annotates warnings with GitHub Action commands. Note that GitHub limits the number of annotations shown.

An example for what a developer would see is:
https://github.com/NickSzapiro-NOAA/ufs-weather-model/actions/runs/29771652448?pr=31 for https://github.com/NickSzapiro-NOAA/ufs-weather-model/pull/31

### Commit Message:
<!--
Provide a concise commit message for the UFS WM and any subcomponents; delete unnecessary info.
-->
```
* UFSWM - Flag compiler warnings in CI builds of operational applications via GitHub Action
```

### Priority:
<!--
Indicate PR priority and include a justification for high/critical priority PRs; delete options that are not applicable. 
-->
- [ ] Critical Bugfix: Reason
- [ ] High: Reason
- [ ] Normal

## Git Tracking
### UFSWM:
<!--
Add the related UFS WM Github Issue here:
-->
* Closes #https://github.com/ufs-community/ufs-weather-model/issues/2703

### Sub component Pull Requests:
<!--
Provide a list of subcomponents involved with this PR and include links to subcomponent PRs.
Example:
* UFSATM: NOAA-EMC/UFSATM#734
  * ccpp-physics: ufs-community/ccpp-physics#33
* WW3: NOAA-EMC/WW3#321
Delete sections that are not needed.
-->
* UFSWM - 
  * AQM - 
  * CATChem - 
  * CDEPS - 
  * CECE - 
  * CICE - 
  * CMEPS - 
  * CMakeModules - 
  * UFSATM - 
    * ccpp-physics -
      * CCPP submodules (list) - 
    * atmos_cubed_sphere -
    * MPAS
  * GOCART -
  * LM4 - 
  * MOM6 - 
  * NOAHMP - 
  * WW3 - 
  * fire_behavior
  * stochastic_physics - 
* None

### UFSWM Blocking Dependencies:
<!--
Please include any UFS WM PRs (with links) that need to be completed before this one; delete what is not needed.
-->
- [ ] Blocked by #
- [ ] None

### Documentation:
<!--
Indicate what documentation, if any, is needed for this PR and who will add it (if applicable).
Delete what is not needed.
-->
- [ ] Documentation update required. 
   - [ ] Relevant updates are included with this PR. 
   - [ ] A WM issue has been opened to track the need for a documentation update; a person responsible for submitting the update has been assigned to the issue (link issue).
- [ ] Documentation update NOT required. 
   - Explanation: 

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
<!--
Indicate whether this PR creates new baselines, changes baselines, or not. Delete what is not needed.
For baseline changes, make sure to submit the test_changes.list file generated by a full RT run (Intel+GNU)
-->
- [ ] PR Adds New Tests/Baselines.
- [ ] PR Updates/Changes Baselines.
- [ ] No Baseline Changes.

### Input data Changes:
<!--
If there are changes to input data for a test, provide information here. Delete options that are not needed.
-->
- [ ] None.
- [ ] PR adds input data.
- [ ] PR changes existing input data.

### Library Changes/Upgrades:
<!-- Library updates take time. Provide library and version information here, and delete what is not needed. 
** SPECIAL INSTRUCTIONS **
- Create a separate issue in (https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
- Add issue link from JCSDA/spack-stack following this item <!-- for example: "* JCSDA/spack-stack#1757"
-->
- [ ] Required
  * Library names w/versions:
  * Git Stack Issue (JCSDA/spack-stack#)
- [ ] No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Orion
  - [ ] Hercules
  - [ ] GaeaC6
  - [ ] Derecho
  - [ ] Ursa
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)

## Testing Remarks:
<!-- Lead CM: List (1) testing issues that we are bypassing (e.g., failing CI due to remarks or an early-merged component PR) 
(2) Issues that have been opened based on testing results (3) any other relevant info -->
- 
